### PR TITLE
bugfix with subtitle

### DIFF
--- a/source/polytechnique.sty
+++ b/source/polytechnique.sty
@@ -300,7 +300,8 @@
 \pagestyle{plain}
 \newboolean{subtitle}\setboolean{subtitle}{false}
 \newcommand{\polysoustitresave}{}
-\newcommand*{\subtitle}[1]{
+\def\subtitle{}
+\renewcommand*{\subtitle}[1]{
     \renewcommand*{\polysoustitresave}{#1}
     \setboolean{subtitle}{true}
 }


### PR DESCRIPTION
In some classes (for example `paper`) the command `\subtitle` already exists, which obviously **creates errors** when we try `\newcommand{\subtitle}{...}` : 

```
! LaTeX Error: Command \subtitle already defined.
```

The thing is we can't put `\renewcommand{\subtitle}{...}` since in most classes `\subtitle` doesn't exist and we would have the error :

```
! LaTeX Error: \subtitle undefined.
```

What I put should do the trick since `\def` (which is a `TeX` command) doesn't care if the command it defines already exists.

_I tested my idea with the two following minimal examples, and then I tried using the package polytechnique in the paper class, which worked._

``` latex
\begin{document}
    \newcommand{\foo}{}
    \def\foo{some text}
\end{document}
```

``` latex
\begin{document}
    \def\foo{some text}
\end{document}
```

``` latex
\documentclass[titlepage, a4paper, 11pt]{paper}
\usepackage{polytechnique}
\usepackage[utf8]{inputenc}
\usepackage[T1]{fontenc}
\usepackage{lmodern}
\usepackage[french]{babel}

\title{LTX101}
\subtitle{LaTeX pour les nuls}
\author{John Doe}

\begin{document}
    \maketitle
\end{document}
```
