### PR TITLE
bug fix on find command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY:all %.all install %.install clean %.clean cleandist %.cleandist release
 
 SUBMAKE:=make -s -C
-SUBMAKABLE:=$(shell find -mindepth 2 -name '[Mm]akefile' | sed 's%^./%%;s%/[^/]*%%')
+SUBMAKABLE:=$(shell find . -mindepth 2 -name '[Mm]akefile' | sed 's%^./%%;s%/[^/]*%%')
 define submake
 	@tput setaf 3
 	@echo make[$1] $2

--- a/source/Makefile
+++ b/source/Makefile
@@ -24,7 +24,7 @@ MAKEINDEX:=makeindex -q -s gind.ist -o
 OUTPUT:=>/dev/null 2>&1
 PKGDIR:=$(shell kpsewhich --show-path=ls-R | tr : '\n' | grep texmf | grep local | head -n1)
 POLYPKGDIR:=$(PKGDIR)/tex/latex/polytechnique
-DTXFILES:=$(shell find -name '*.dtx')
+DTXFILES:=$(shell find . -name '*.dtx')
 GENFILES:=$(patsubst %.dtx,%.pdf,$(DTXFILES)) $(patsubst %.dtx,%.sty,$(DTXFILES))
 
 all: package


### PR DESCRIPTION
On Mac OS, an error about find was caused as follows:
```
find: illegal option -- m
```
this path is to fix it.
